### PR TITLE
Implementar dashboard de gestión de pedidos

### DIFF
--- a/sistema-pedidos/src/App.css
+++ b/sistema-pedidos/src/App.css
@@ -1,42 +1,450 @@
 #root {
-  max-width: 1280px;
+  max-width: 1200px;
   margin: 0 auto;
+  padding: 2.5rem 1.5rem 3rem;
+}
+
+.app-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-header {
+  background-color: #ffffff;
+  border-radius: 16px;
   padding: 2rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  border: 1px solid #e3e8ee;
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+  color: #111827;
+}
+
+.app-header p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 1rem;
+}
+
+.app-controls {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 280px) minmax(0, 1fr);
+  align-items: stretch;
+}
+
+.app-dashboard {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.app-panel {
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 1.75rem;
+  border: 1px solid #e3e8ee;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.app-panel h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #111827;
+}
+
+.app-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.app-panel__filter {
+  background-color: #eef2ff;
+  color: #4338ca;
+  font-weight: 600;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.order-filter {
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid #e3e8ee;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-filter__label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.order-filter__select {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  background-color: #f8fafc;
+  color: #1f2937;
+}
+
+.order-stats {
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px solid #e3e8ee;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-stats__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #111827;
+}
+
+.order-stats__total {
+  margin: 0;
+  color: #4b5563;
+  font-size: 1rem;
+}
+
+.order-stats__grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.order-stats__card {
+  background-color: #f8fafc;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-stats__count {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.order-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: capitalize;
+  font-size: 0.85rem;
+}
+
+.order-status--pending {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.order-status--shipped {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
+
+.order-status--delivered {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-list__empty {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 1px dashed #cbd5f5;
+  background-color: #f8fafc;
+  color: #4b5563;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.order-card {
+  background-color: #ffffff;
+  border-radius: 14px;
+  padding: 1.5rem;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.order-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.order-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #111827;
+}
+
+.order-card__customer {
+  margin: 0.25rem 0 0;
+  color: #4b5563;
+}
+
+.order-card__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.order-card__date {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.order-card__products {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-card__product {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  border-bottom: 1px solid #f1f5f9;
+  padding-bottom: 0.75rem;
+}
+
+.order-card__product:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.order-card__product-name {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.order-card__product-quantity {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.order-card__product-prices {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  min-width: 120px;
+}
+
+.order-card__product-subtotal {
+  font-weight: 600;
+  color: #111827;
+}
+
+.order-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid #e5e7eb;
+  padding-top: 1rem;
+  margin-top: 0.5rem;
+  font-size: 1rem;
+}
+
+.order-card__footer strong {
+  font-size: 1.1rem;
+}
+
+.order-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.order-form__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-form__group label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.order-form__group input,
+.order-form__group select,
+.order-form__product-row input {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  background-color: #f8fafc;
+  color: #1f2937;
+}
+
+.order-form__group--inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.order-form__group--inline > div {
+  flex: 1 1 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-form__fieldset {
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-form__fieldset legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.order-form__product-row {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.order-form__product-row input[type='number'] {
+  text-align: right;
+}
+
+.order-form__remove,
+.order-form__add,
+.order-form__submit {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.order-form__remove {
+  background-color: #fee2e2;
+  color: #b91c1c;
+}
+
+.order-form__remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.order-form__add {
+  align-self: flex-start;
+  background-color: #e0e7ff;
+  color: #3730a3;
+}
+
+.order-form__submit {
+  align-self: flex-end;
+  background-color: #4f46e5;
+  color: #ffffff;
+  padding: 0.75rem 1.75rem;
+  box-shadow: 0 12px 20px rgba(79, 70, 229, 0.25);
+}
+
+.order-form__remove:hover:not(:disabled),
+.order-form__add:hover,
+.order-form__submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+}
+
+.order-form__error {
+  margin: 0;
+  color: #b91c1c;
+  font-weight: 600;
+  background-color: #fee2e2;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
+.order-form__success {
+  margin: 0;
+  color: #166534;
+  font-weight: 600;
+  background-color: #dcfce7;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
+@media (max-width: 1024px) {
+  .app-dashboard {
+    grid-template-columns: 1fr;
   }
-  to {
-    transform: rotate(360deg);
+}
+
+@media (max-width: 768px) {
+  #root {
+    padding: 1.5rem 1rem 2rem;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .app-controls {
+    grid-template-columns: 1fr;
   }
-}
 
-.card {
-  padding: 2em;
-}
+  .order-form__product-row {
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: auto;
+  }
 
-.read-the-docs {
-  color: #888;
+  .order-form__product-row input:nth-child(1) {
+    grid-column: span 2;
+  }
+
+  .order-form__product-row button {
+    grid-column: span 2;
+    justify-self: flex-start;
+  }
 }

--- a/sistema-pedidos/src/App.jsx
+++ b/sistema-pedidos/src/App.jsx
@@ -1,34 +1,169 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useMemo, useState } from 'react'
 import './App.css'
+import OrderFilter from './components/OrderFilter.jsx'
+import OrderForm from './components/OrderForm.jsx'
+import OrderList from './components/OrderList.jsx'
+import OrderStats from './components/OrderStats.jsx'
+import { DEFAULT_ORDER_STATUS, ORDER_STATUS_LABELS } from './constants.js'
+
+const DEFAULT_ORDERS = [
+  {
+    id: '0001',
+    customer: 'Laura Fernández',
+    status: 'pending',
+    date: '2024-04-12',
+    products: [
+      { name: 'Caja de embalaje', quantity: 3, price: 8500 },
+      { name: 'Etiqueta térmica', quantity: 10, price: 320 },
+    ],
+  },
+  {
+    id: '0002',
+    customer: 'Juan Pérez',
+    status: 'shipped',
+    date: '2024-04-10',
+    products: [
+      { name: 'Organizador de escritorio', quantity: 1, price: 18450 },
+      { name: 'Lapiceras', quantity: 5, price: 750 },
+    ],
+  },
+  {
+    id: '0003',
+    customer: 'María González',
+    status: 'delivered',
+    date: '2024-04-01',
+    products: [
+      { name: 'Auriculares bluetooth', quantity: 2, price: 21999 },
+    ],
+  },
+]
+
+function normalizeDateString(dateValue) {
+  const referenceDate = dateValue ? new Date(dateValue) : new Date()
+
+  if (Number.isNaN(referenceDate.getTime())) {
+    throw new Error('La fecha del pedido no es válida.')
+  }
+
+  return referenceDate.toISOString().split('T')[0]
+}
+
+function normalizeProducts(products = []) {
+  if (products.length === 0) {
+    throw new Error('El pedido debe incluir al menos un producto.')
+  }
+
+  return products.map((product, index) => {
+    const name = product.name?.trim()
+    const quantity = Number(product.quantity)
+    const price = Number(product.price)
+
+    if (!name) {
+      throw new Error(`El producto #${index + 1} debe tener un nombre.`)
+    }
+
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      throw new Error(`La cantidad del producto "${name}" debe ser mayor a 0.`)
+    }
+
+    if (!Number.isFinite(price) || price < 0) {
+      throw new Error(`El precio del producto "${name}" no puede ser negativo.`)
+    }
+
+    return {
+      name,
+      quantity,
+      price,
+    }
+  })
+}
+
+function getNextOrderId(orders) {
+  const lastId = orders.reduce((maxId, order) => {
+    const numericId = Number.parseInt(order.id, 10)
+
+    if (Number.isNaN(numericId)) {
+      return maxId
+    }
+
+    return Math.max(maxId, numericId)
+  }, 0)
+
+  const nextNumericId = lastId + 1
+  return nextNumericId.toString().padStart(4, '0')
+}
+
+function createOrder(orderDraft, existingOrders) {
+  const customer = orderDraft.customer?.trim() ?? ''
+
+  if (customer.length < 3) {
+    throw new Error('El nombre del cliente debe tener al menos 3 caracteres.')
+  }
+
+  const status = orderDraft.status && ORDER_STATUS_LABELS[orderDraft.status]
+    ? orderDraft.status
+    : DEFAULT_ORDER_STATUS
+
+  const date = normalizeDateString(orderDraft.date)
+  const products = normalizeProducts(orderDraft.products)
+
+  return {
+    id: getNextOrderId(existingOrders),
+    customer,
+    status,
+    date,
+    products,
+  }
+}
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [orders, setOrders] = useState(DEFAULT_ORDERS)
+  const [selectedStatus, setSelectedStatus] = useState('all')
+
+  const filteredOrders = useMemo(() => {
+    if (selectedStatus === 'all') {
+      return orders
+    }
+
+    return orders.filter((order) => order.status === selectedStatus)
+  }, [orders, selectedStatus])
+
+  const handleAddOrder = (orderDraft) => {
+    setOrders((previousOrders) => {
+      const newOrder = createOrder(orderDraft, previousOrders)
+      return [...previousOrders, newOrder]
+    })
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="app-container">
+      <header className="app-header">
+        <h1>Sistema de Gestión de Pedidos</h1>
+        <p>Gestioná los pedidos de MailAméricas con información clara y validaciones de negocio.</p>
+      </header>
+
+      <section className="app-controls">
+        <OrderFilter selectedStatus={selectedStatus} onChange={setSelectedStatus} />
+        <OrderStats orders={orders} />
+      </section>
+
+      <div className="app-dashboard">
+        <section className="app-panel">
+          <div className="app-panel__header">
+            <h2>Pedidos</h2>
+            {selectedStatus !== 'all' && (
+              <span className="app-panel__filter">Filtro: {ORDER_STATUS_LABELS[selectedStatus]}</span>
+            )}
+          </div>
+          <OrderList orders={filteredOrders} />
+        </section>
+
+        <section className="app-panel">
+          <h2>Agregar nuevo pedido</h2>
+          <OrderForm onSubmit={handleAddOrder} />
+        </section>
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </div>
   )
 }
 

--- a/sistema-pedidos/src/components/OrderFilter.jsx
+++ b/sistema-pedidos/src/components/OrderFilter.jsx
@@ -1,0 +1,26 @@
+import { ORDER_STATUSES } from '../constants.js'
+
+function OrderFilter({ selectedStatus, onChange }) {
+  return (
+    <div className="order-filter">
+      <label className="order-filter__label" htmlFor="order-status-filter">
+        Filtrar por estado
+      </label>
+      <select
+        id="order-status-filter"
+        className="order-filter__select"
+        value={selectedStatus}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        <option value="all">Todos</option>
+        {ORDER_STATUSES.map((status) => (
+          <option key={status.value} value={status.value}>
+            {status.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export default OrderFilter

--- a/sistema-pedidos/src/components/OrderForm.jsx
+++ b/sistema-pedidos/src/components/OrderForm.jsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+import { DEFAULT_ORDER_STATUS, ORDER_STATUSES } from '../constants.js'
+
+const TODAY = new Date().toISOString().split('T')[0]
+
+function createEmptyProduct() {
+  return {
+    name: '',
+    quantity: 1,
+    price: 0,
+  }
+}
+
+function OrderForm({ onSubmit }) {
+  const [customer, setCustomer] = useState('')
+  const [status, setStatus] = useState(DEFAULT_ORDER_STATUS)
+  const [date, setDate] = useState(TODAY)
+  const [products, setProducts] = useState([createEmptyProduct()])
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const handleProductChange = (index, field, value) => {
+    setProducts((previousProducts) => {
+      return previousProducts.map((product, productIndex) => {
+        if (productIndex !== index) {
+          return product
+        }
+
+        if (field === 'quantity' || field === 'price') {
+          const numericValue = value === '' ? value : Number(value)
+          return { ...product, [field]: numericValue }
+        }
+
+        return { ...product, [field]: value }
+      })
+    })
+  }
+
+  const handleAddProduct = () => {
+    setProducts((previousProducts) => [...previousProducts, createEmptyProduct()])
+  }
+
+  const handleRemoveProduct = (indexToRemove) => {
+    setProducts((previousProducts) => {
+      if (previousProducts.length === 1) {
+        return previousProducts
+      }
+
+      return previousProducts.filter((_, index) => index !== indexToRemove)
+    })
+  }
+
+  const resetForm = () => {
+    setCustomer('')
+    setStatus(DEFAULT_ORDER_STATUS)
+    setDate(TODAY)
+    setProducts([createEmptyProduct()])
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+
+    const orderDraft = {
+      customer,
+      status,
+      date,
+      products: products.map((product) => ({
+        name: product.name,
+        quantity: Number(product.quantity),
+        price: Number(product.price),
+      })),
+    }
+
+    try {
+      onSubmit(orderDraft)
+      setError('')
+      setSuccess('Pedido agregado correctamente.')
+      resetForm()
+    } catch (submissionError) {
+      setSuccess('')
+      setError(submissionError.message)
+    }
+  }
+
+  return (
+    <form className="order-form" onSubmit={handleSubmit}>
+      <div className="order-form__group">
+        <label htmlFor="order-customer">Cliente</label>
+        <input
+          id="order-customer"
+          name="customer"
+          type="text"
+          value={customer}
+          onChange={(event) => setCustomer(event.target.value)}
+          placeholder="Ej: Ana Martínez"
+          minLength={3}
+          required
+        />
+      </div>
+
+      <div className="order-form__group order-form__group--inline">
+        <div>
+          <label htmlFor="order-status">Estado</label>
+          <select
+            id="order-status"
+            name="status"
+            value={status}
+            onChange={(event) => setStatus(event.target.value)}
+          >
+            {ORDER_STATUSES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="order-date">Fecha</label>
+          <input
+            id="order-date"
+            name="date"
+            type="date"
+            value={date}
+            onChange={(event) => setDate(event.target.value)}
+            max={TODAY}
+          />
+        </div>
+      </div>
+
+      <fieldset className="order-form__fieldset">
+        <legend>Productos</legend>
+        {products.map((product, index) => (
+          <div key={`product-${index}`} className="order-form__product-row">
+            <input
+              type="text"
+              placeholder="Nombre del producto"
+              value={product.name}
+              onChange={(event) => handleProductChange(index, 'name', event.target.value)}
+              required
+            />
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={product.quantity}
+              onChange={(event) => handleProductChange(index, 'quantity', event.target.value)}
+              required
+            />
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={product.price}
+              onChange={(event) => handleProductChange(index, 'price', event.target.value)}
+              required
+            />
+            <button
+              type="button"
+              className="order-form__remove"
+              onClick={() => handleRemoveProduct(index)}
+              disabled={products.length === 1}
+            >
+              Quitar
+            </button>
+          </div>
+        ))}
+        <button type="button" className="order-form__add" onClick={handleAddProduct}>
+          Agregar producto
+        </button>
+      </fieldset>
+
+      {error && <p className="order-form__error">{error}</p>}
+      {success && <p className="order-form__success">{success}</p>}
+
+      <button type="submit" className="order-form__submit">
+        Guardar pedido
+      </button>
+    </form>
+  )
+}
+
+export default OrderForm

--- a/sistema-pedidos/src/components/OrderItem.jsx
+++ b/sistema-pedidos/src/components/OrderItem.jsx
@@ -1,0 +1,80 @@
+import { ORDER_STATUS_LABELS } from '../constants.js'
+
+const currencyFormatter = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS',
+})
+
+const DATE_FORMAT_OPTIONS = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+}
+
+function formatDate(dateValue) {
+  const parsedDate = dateValue ? new Date(dateValue) : new Date()
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return dateValue
+  }
+
+  return parsedDate.toLocaleDateString('es-AR', DATE_FORMAT_OPTIONS)
+}
+
+function calculateOrderTotal(products) {
+  return products.reduce((total, product) => {
+    return total + product.quantity * product.price
+  }, 0)
+}
+
+function OrderItem({ order }) {
+  const total = calculateOrderTotal(order.products)
+
+  return (
+    <article className={`order-card order-card--${order.status}`}>
+      <header className="order-card__header">
+        <div>
+          <h3 className="order-card__title">Pedido #{order.id}</h3>
+          <p className="order-card__customer">{order.customer}</p>
+        </div>
+        <div className="order-card__meta">
+          <span className={`order-status order-status--${order.status}`}>
+            {ORDER_STATUS_LABELS[order.status] ?? order.status}
+          </span>
+          <time className="order-card__date" dateTime={order.date}>
+            {formatDate(order.date)}
+          </time>
+        </div>
+      </header>
+
+      <ul className="order-card__products">
+        {order.products.map((product, index) => {
+          const subtotal = product.quantity * product.price
+          return (
+            <li key={`${product.name}-${index}`} className="order-card__product">
+              <div>
+                <p className="order-card__product-name">{product.name}</p>
+                <p className="order-card__product-quantity">
+                  Cantidad: {product.quantity}
+                </p>
+              </div>
+              <div className="order-card__product-prices">
+                <span>{currencyFormatter.format(product.price)}</span>
+                <span className="order-card__product-subtotal">
+                  {currencyFormatter.format(subtotal)}
+                </span>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      <footer className="order-card__footer">
+        <span>Total del pedido</span>
+        <strong>{currencyFormatter.format(total)}</strong>
+      </footer>
+    </article>
+  )
+}
+
+export default OrderItem

--- a/sistema-pedidos/src/components/OrderList.jsx
+++ b/sistema-pedidos/src/components/OrderList.jsx
@@ -1,0 +1,17 @@
+import OrderItem from './OrderItem.jsx'
+
+function OrderList({ orders }) {
+  if (orders.length === 0) {
+    return <p className="order-list__empty">No hay pedidos para mostrar.</p>
+  }
+
+  return (
+    <div className="order-list">
+      {orders.map((order) => (
+        <OrderItem key={order.id} order={order} />
+      ))}
+    </div>
+  )
+}
+
+export default OrderList

--- a/sistema-pedidos/src/components/OrderStats.jsx
+++ b/sistema-pedidos/src/components/OrderStats.jsx
@@ -1,0 +1,36 @@
+import { ORDER_STATUSES, ORDER_STATUS_LABELS } from '../constants.js'
+
+function OrderStats({ orders }) {
+  const totalOrders = orders.length
+
+  const totalsByStatus = orders.reduce((totals, order) => {
+    const currentTotal = totals[order.status] ?? 0
+    return {
+      ...totals,
+      [order.status]: currentTotal + 1,
+    }
+  }, {})
+
+  return (
+    <section className="order-stats">
+      <h2 className="order-stats__title">Estadísticas generales</h2>
+      <p className="order-stats__total">
+        Total de pedidos: <strong>{totalOrders}</strong>
+      </p>
+      <div className="order-stats__grid">
+        {ORDER_STATUSES.map((status) => (
+          <article key={status.value} className="order-stats__card">
+            <span className={`order-status order-status--${status.value}`}>
+              {ORDER_STATUS_LABELS[status.value]}
+            </span>
+            <span className="order-stats__count">
+              {totalsByStatus[status.value] ?? 0}
+            </span>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default OrderStats

--- a/sistema-pedidos/src/constants.js
+++ b/sistema-pedidos/src/constants.js
@@ -1,0 +1,11 @@
+export const ORDER_STATUSES = [
+  { value: 'pending', label: 'Pendiente' },
+  { value: 'shipped', label: 'Enviado' },
+  { value: 'delivered', label: 'Entregado' },
+]
+
+export const ORDER_STATUS_LABELS = ORDER_STATUSES.reduce((labels, status) => {
+  return { ...labels, [status.value]: status.label }
+}, {})
+
+export const DEFAULT_ORDER_STATUS = 'pending'

--- a/sistema-pedidos/src/index.css
+++ b/sistema-pedidos/src/index.css
@@ -1,68 +1,29 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #1f2937;
+  background-color: #f4f6fb;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background-color: #f4f6fb;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- crear componentes dedicados para filtrar, listar, resumir y cargar pedidos con validaciones de negocio
- centralizar los estados y etiquetas de pedidos y normalizar la creación de órdenes nuevas en la aplicación principal
- actualizar los estilos globales para presentar un dashboard responsive y un formulario usable

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc15668a44832d82079d47a29c095c